### PR TITLE
Bug Fix Copy button doesn't copy values correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "country-codes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "country-codes",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-codes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/components/common/CopyButton.js
+++ b/src/components/common/CopyButton.js
@@ -20,6 +20,10 @@ export class CopyButton extends Component {
     this.setClipboard = this.setClipboard.bind(this);
   }
 
+  static getDerivedStateFromProps(props, state) {
+    return {copyContent: props.copyContent };
+  }
+
   componentDidUpdate() {
     if (this.state.copyState === true) {
       setTimeout(() => {
@@ -32,7 +36,8 @@ export class CopyButton extends Component {
   }
 
   setClipboard() {
-    if (copy(this.state.copyContent)) {
+    copy("");
+    if (copy(this.state.copyContent, { format: "text/plain" })) {
       this.setState({
         copyState: true,
         buttonTitle: "Copied",


### PR DESCRIPTION
**Changelog**

Bug Fix: #14  Copy to Clipboard button doesn't work when country names copy + pasted into the search.

Version Patch 0.1.1