### PR TITLE
Added space around attribution links in About page

### DIFF
--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -45,7 +45,13 @@ function OSLibraries() {
   ).map((library, i) => {
     return (
       <Fragment key={i}>
-        <a href={library.href} target="_blank" rel="noreferrer" key={i}>
+        <a
+          href={library.href}
+          className="me-2 text-nowrap"
+          target="_blank"
+          rel="noreferrer"
+          key={i}
+        >
           {library.name} <ExternalLinkSvg />
         </a>{" "}
       </Fragment>


### PR DESCRIPTION
Tap targets are not sized appropriately on the About page

Fixes #47