### PR TITLE
Adjust line height for Attribution links

### DIFF
--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -94,7 +94,7 @@ export class About extends Component {
                 </p>
                 <dl className="row mb-0">
                   <dt className="col-sm-3">Open Source Attributions:</dt>
-                  <dd className="col-sm-9">
+                  <dd className="col-sm-9 lh-lg">
                     <OSLibraries />
                   </dd>
                 </dl>


### PR DESCRIPTION
Fixes Tap targets are not sized appropriately on About page #47